### PR TITLE
Email regex fixes

### DIFF
--- a/regexsnippets.code-snippets
+++ b/regexsnippets.code-snippets
@@ -1,7 +1,7 @@
 {
     "Validate E-Mail Address": {
         "prefix": "!valemail",
-        "body": "/[A-Z0-9._%+-]+@[A-Z0-9-]+.+.[A-Z]{2,4}/igm",
+        "body": "/^[A-Z0-9!#$%&'*+/=?^_`{|}~-][A-Z0-9!#$%&'*+/=?^_`{|}~.-]*[A-Z0-9!#$%&'*+/=?^_`{|}~-]@[A-Z0-9][A-Z0-9-]*\\.[A-Z0-9-]*[A-Z0-9]$/igm",
         "description": "Validates the given email address"
     },
     "Validate Hexadecimal Color Value": {
@@ -253,7 +253,7 @@
         "prefix": "!tocamel",
         "body": "${1: string}.replace(/(?:^\\w|[A-Z]|\b\\w)/g, function(word, index) {return index === 0 ? word.toLowerCase() : word.toUpperCase();}).replace(/\\s+/g, '');",
         "description": "Returns a function which converts the given string to camelCase"
-    }.
+    },
     "Balanced Paranthesis Validation": {
         "prefix": "!valbracks",
         "body": "\\((?>\\((?<c>)|[^()]+|\\)(?<-c>))*(?(c)(?!))\\)",


### PR DESCRIPTION
Fixes #8 

Added all special characters allowed in local part.
Remove catch-all wildcard (`.`) in domain part.
Allow top-level domains of more than 4 characters.