### PR TITLE
Fixed email address validation regex

### DIFF
--- a/regexsnippets.code-snippets
+++ b/regexsnippets.code-snippets
@@ -1,7 +1,7 @@
 {
     "Validate E-Mail Address": {
         "prefix": "!valemail",
-        "body": "/^[A-Z0-9!#$%&'*+/=?^_`{|}~-][A-Z0-9!#$%&'*+/=?^_`{|}~.-]*[A-Z0-9!#$%&'*+/=?^_`{|}~-]@[A-Z0-9][A-Z0-9-]*\\.[A-Z0-9-]*[A-Z0-9]$/igm",
+        "body": "/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/igm",
         "description": "Validates the given email address"
     },
     "Validate Hexadecimal Color Value": {


### PR DESCRIPTION
The original latest code is escaping a back slash instead of escaping the dot, but the expression fails subdomains check such as `@gmail.com.edu` so there is a community pattern that is already a good fit and works flawlessly so far so it is added into the commit

### Please check if the PR fulfills these requirements:

* [x] The PR title and message describe the solution briefly.
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
fixes #21 
Also fixes email validation regex snippet where there was a typo maybe and instead of escaping the dot `.` the character being escaped was a backslash `\`. 

### What is the new behavior?
Matches emails correctly and works with subdomains as well such as `@gmail.com.edu`

### Other information?
<!-- Is this a breaking change? -->
This is a significant change and improves on the email validation regex snippet
<!-- How did you test -->
Tested manually on https://regexr.com/
Credits to the expression goes to: https://regexr.com/2rhq7